### PR TITLE
AST representation for verification constructs + integration to existing pipeline steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ bin/
 coverage/
 
 *.pptx
+
+testout/

--- a/README.md
+++ b/README.md
@@ -146,16 +146,57 @@ for var i = 0; i < #array; i += 1 {
 when <cond> then <expr1> else <expr2>
 ```
 
-#### Cast/type conversion
+### Cast/type conversion
 The following conversions can be performed:
 - `Int` <-> `Char`
 - `Int` <-> `Double`
 
 Syntax: `<expr> as <type>`, e.g. `10 as Double`
 
-#### Panic
+### Panic
 Terminates the program with an exception
 `panic <message>`, e.g. `panic "forbidden argument " + arg`
+
+### Verification
+
+#### Assertions
+
+```
+assert <predicate>
+```
+
+#### Preconditions and postconditions
+
+`require` and `ensure`:
+```
+fn foo(x: Int, y: Int) -> Int
+require x > 0
+require y >= 0
+{
+    return 2*x + y
+}
+ensure result > y
+```
+
+#### Loop invariant
+
+Checked at the beginning of each iteration as well as when the loop is exited
+
+For loop:
+```
+var sum = 0;
+for var i = 0; i < #xs; i += 1 invar sum >= 0 {
+    sum += xs[i]
+}
+```
+
+While loop:
+```
+while x < 20 && y < 100 invar x < y {
+    ...
+}
+```
+
 
 ## Built-in functions
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -156,6 +156,10 @@ object Main {
     getUnvalArg("all-parenth", argsMap)
   }
 
+  private def getDesugarOperatorsArg(argsMap: MutArgsMap): Boolean = {
+    getUnvalArg("desugar-ops", argsMap)
+  }
+
   private def getProgramArgsArg(argsMap: MutArgsMap): Array[String] = {
     val emptyArrStr = "[]"
     val arrayStr = getValuedArg("args", argsMap, Some(emptyArrStr))
@@ -276,6 +280,7 @@ object Main {
       val desugarer = TasksPipelines.desugarer(
         getOutDirArg(argsMap),
         getOutputNameArg(sources, argsMap, Path.of(sources.head.name).getFileName.toString),
+        getDesugarOperatorsArg(argsMap),
         getIndentGranularityArg(argsMap),
         quest => yesNoQuestion(quest),
         getPrintAllParenthesesArg(argsMap)
@@ -336,6 +341,8 @@ object Main {
         |desugar: show the file after desugaring
         | args: -out-dir=...: required, directory where to write the output file
         |       -out-file=...: optional, output file name (by default same as input)
+        |       -desugar-ops: flag indicating that desugaring must be complete, i.e. that operators should be desugared
+        |                     (e.g.  `x && y`  is desugared to  `when x then y else false` )
         |       -indent=...: optional, indent granularity (2 by default)
         |       -all-parenth: flag indicating that all parentheses should be displayed in expressions,
         |                     regardless of the priority of operations (takes no value)

--- a/src/main/scala/compiler/AnalysisContext.scala
+++ b/src/main/scala/compiler/AnalysisContext.scala
@@ -31,7 +31,9 @@ final case class AnalysisContext(functions: Map[String, FunctionInfo], structs: 
 
 object AnalysisContext {
 
-  final case class FunctionInfo(sig: FunctionSignature, precond: List[Expr], postcond: List[Expr])
+  final case class FunctionInfo(sig: FunctionSignature, precond: List[Expr], postcond: List[Expr], optDef: Option[FunDef]){
+    def isBuiltin: Boolean = optDef.isEmpty
+  }
 
   final class Builder(errorReporter: ErrorReporter) {
     private val functions: mutable.Map[String, FunctionInfo] = mutable.Map.empty
@@ -44,7 +46,7 @@ object AnalysisContext {
       } else if (functions.contains(name)) {
         errorReporter.push(Err(ContextCreation, s"redefinition of function '$name'", funDef.getPosition))
       } else {
-        functions.put(name, FunctionInfo(funDef.signature, funDef.precond, funDef.postcond))
+        functions.put(name, FunctionInfo(funDef.signature, funDef.precond, funDef.postcond, Some(funDef)))
       }
     }
 
@@ -69,7 +71,7 @@ object AnalysisContext {
     }
 
     def build(): AnalysisContext = {
-      functions.addAll(BuiltInFunctions.builtInFunctions.map((name, func) => name -> FunctionInfo(func, Nil, Nil)))
+      functions.addAll(BuiltInFunctions.builtInFunctions.map((name, func) => name -> FunctionInfo(func, Nil, Nil, None)))
       new AnalysisContext(functions.toMap, structs.toMap)
     }
 

--- a/src/main/scala/compiler/FunctionsToInject.scala
+++ b/src/main/scala/compiler/FunctionsToInject.scala
@@ -29,7 +29,7 @@ object FunctionsToInject {
         .andThen(Mapper(List(_)))
         .andThen(new ContextCreator(er, functionsToInject = Nil))
         .andThen(new TypeChecker(er))
-        .andThen(new Desugarer())
+        .andThen(new Desugarer(desugarOperators = true))
 
     // load code of the function, desugar it and replace its name
     val resFile = SourceFile("res/streq.rsn")

--- a/src/main/scala/compiler/Replacer.scala
+++ b/src/main/scala/compiler/Replacer.scala
@@ -1,0 +1,49 @@
+package compiler
+
+import compiler.irs.Asts.*
+
+object Replacer {
+
+  def replaceInExpr[E <: Expr](expr: E, renameMap: Map[String, Expr]): E = {
+    replaceInExprImpl(expr)(renameMap)
+  }
+
+  private def replaceInExprImpl[E <: Expr](expr: E)(implicit replMap: Map[String, Expr]): E = {
+    val resExpr = expr match {
+      case _: Literal => expr
+      case varRef@VariableRef(name) => replMap.getOrElse(name, varRef)
+      case Call(callee, args) => Call(replaceInExprImpl(callee), args.map(replaceInExprImpl))
+      case Indexing(indexed, arg) => Indexing(replaceInExprImpl(indexed), replaceInExprImpl(arg))
+      case ArrayInit(elemType, size) => ArrayInit(elemType, replaceInExprImpl(size))
+      case FilledArrayInit(arrayElems) => FilledArrayInit(arrayElems.map(replaceInExprImpl))
+      case StructInit(structName, args) => StructInit(structName, args.map(replaceInExprImpl))
+      case UnaryOp(operator, operand) => UnaryOp(operator, replaceInExprImpl(operand))
+      case BinaryOp(lhs, operator, rhs) => BinaryOp(replaceInExprImpl(lhs), operator, replaceInExprImpl(rhs))
+      case Select(lhs, selected) => Select(replaceInExprImpl(lhs), selected)
+      case Ternary(cond, thenBr, elseBr) => Ternary(replaceInExprImpl(cond), replaceInExprImpl(thenBr), replaceInExprImpl(elseBr))
+      case Cast(expr, tpe) => Cast(replaceInExprImpl(expr), tpe)
+      case Sequence(stats, expr) => Sequence(stats.map(renameInStat), replaceInExprImpl(expr))
+    }
+    resExpr.setTypeOpt(expr.getTypeOpt)
+    resExpr.asInstanceOf[E]
+  }
+
+  private def renameInStat[S <: Statement](stat: S)(implicit replMap: Map[String, Expr]): S = {
+    val resStat = stat match {
+      case expr: Expr => replaceInExprImpl(expr)
+      case Block(stats) => Block(stats.map(renameInStat))
+      case VarAssig(lhs, rhs) => VarAssig(replaceInExprImpl(lhs), replaceInExprImpl(rhs))
+      case VarModif(lhs, rhs, op) => VarModif(replaceInExprImpl(lhs), replaceInExprImpl(rhs), op)
+      case IfThenElse(cond, thenBr, elseBrOpt) => IfThenElse(replaceInExprImpl(cond), renameInStat(thenBr), elseBrOpt.map(renameInStat))
+      case WhileLoop(cond, body, invariants) => WhileLoop(replaceInExprImpl(cond), renameInStat(body), invariants.map(replaceInExprImpl))
+      case ForLoop(initStats, cond, stepStats, body, invariants) =>
+        ForLoop(initStats.map(renameInStat), replaceInExprImpl(cond), stepStats.map(renameInStat), renameInStat(body), invariants.map(replaceInExprImpl))
+      case ReturnStat(optVal) => ReturnStat(optVal.map(replaceInExprImpl))
+      case Assertion(formulaExpr, isAssumed) => Assertion(replaceInExprImpl(formulaExpr), isAssumed)
+      case _: PanicStat => stat
+      case _: LocalDef => assert(false)
+    }
+    resStat.asInstanceOf[S]
+  }
+
+}

--- a/src/main/scala/compiler/backend/Backend.scala
+++ b/src/main/scala/compiler/backend/Backend.scala
@@ -115,7 +115,7 @@ final class Backend[V <: ClassVisitor](
     }
     mv.visitCode()
     generateCode(funDef.body, ctx)(mv, outputName)
-    if (ctx.analysisContext.functions.apply(funDef.funName).retType == VoidType) {
+    if (ctx.analysisContext.functions.apply(funDef.funName).sig.retType == VoidType) {
       mv.visitInsn(Opcodes.RETURN)
     }
     mv.visitMaxs(0, 0)  // parameters are ignored because mode is COMPUTE_FRAMES
@@ -168,7 +168,7 @@ final class Backend[V <: ClassVisitor](
           }
         } else {
           generateArgs()
-          val descriptor = descriptorForFunc(analysisContext.functions.apply(name))
+          val descriptor = descriptorForFunc(analysisContext.functions.apply(name).sig)
           mv.visitMethodInsn(Opcodes.INVOKESTATIC, outputName, name, descriptor, false)
         }
       }
@@ -361,7 +361,7 @@ final class Backend[V <: ClassVisitor](
       case Ternary(cond, thenBr, elseBr) =>
         generateIfThenElse(ctx, cond, thenBr, Some(elseBr))
 
-      case WhileLoop(cond, body) =>
+      case WhileLoop(cond, body, _) =>
         /*
          * loopLabel:
          *   if !cond goto endLabel

--- a/src/main/scala/compiler/backend/Backend.scala
+++ b/src/main/scala/compiler/backend/Backend.scala
@@ -6,6 +6,7 @@ import compiler.backend.BuiltinFunctionsImpl.*
 import compiler.backend.DescriptorsCreator.{descriptorForFunc, descriptorForType}
 import compiler.backend.TypesConverter.{convertToAsmType, convertToAsmTypeCode, internalNameOf, opcodeFor}
 import compiler.irs.Asts.*
+import compiler.prettyprinter.PrettyPrinter
 import compiler.{AnalysisContext, CompilerStep, FileExtensions}
 import lang.Operator.*
 import lang.Types.PrimitiveType.*
@@ -23,9 +24,10 @@ import scala.util.{Failure, Success, Try, Using}
 
 /**
  * Generates the output files: 1 core file, containing the program, and 1 file per struct
- * @param mode cf nested class [[Backend.Mode]]
+ *
+ * @param mode          cf nested class [[Backend.Mode]]
  * @param outputDirBase output directory path (will be extended with `/out`)
- * @param outputName name of the output file
+ * @param outputName    name of the output file
  * @tparam V depends on the mode
  */
 final class Backend[V <: ClassVisitor](
@@ -104,7 +106,7 @@ final class Backend[V <: ClassVisitor](
     constructorVisitor.visitVarInsn(Opcodes.ALOAD, 0)
     constructorVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
     constructorVisitor.visitInsn(Opcodes.RETURN)
-    constructorVisitor.visitMaxs(0, 0)  // parameters are ignored because mode is COMPUTE_FRAMES
+    constructorVisitor.visitMaxs(0, 0) // parameters are ignored because mode is COMPUTE_FRAMES
     constructorVisitor.visitEnd()
   }
 
@@ -118,7 +120,7 @@ final class Backend[V <: ClassVisitor](
     if (ctx.analysisContext.functions.apply(funDef.funName).sig.retType == VoidType) {
       mv.visitInsn(Opcodes.RETURN)
     }
-    mv.visitMaxs(0, 0)  // parameters are ignored because mode is COMPUTE_FRAMES
+    mv.visitMaxs(0, 0) // parameters are ignored because mode is COMPUTE_FRAMES
     mv.visitEnd()
   }
 
@@ -388,7 +390,7 @@ final class Backend[V <: ClassVisitor](
 
       case Cast(expr, tpe) => {
         generateCode(expr, ctx)
-        if (!expr.getType.subtypeOf(tpe)){
+        if (!expr.getType.subtypeOf(tpe)) {
           // typechecker checked that it is defined, so .get without check
           TypeConversion.conversionFor(expr.getType, tpe).get match
             case TypeConversion.Int2Double => mv.visitInsn(Opcodes.I2D)
@@ -399,16 +401,38 @@ final class Backend[V <: ClassVisitor](
       }
 
       case PanicStat(msg) =>
-        // throw an exception
-        mv.visitTypeInsn(NEW, "java/lang/RuntimeException")
-        mv.visitInsn(DUP)
-        generateCode(msg, ctx)
-        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/RuntimeException",
-          "<init>", s"(L$stringTypeStr;)V", false)
-        mv.visitInsn(Opcodes.ATHROW)
+        generateExceptionCode(ctx, msg)
+
+      case assertion@Assertion(formulaExpr, descr, isAssumed) =>
+        /*
+         *  if formulaExpr != 0 goto OK_label
+         *    throw Exception
+         * OK_label:
+         */
+        val descriptiveWord = if isAssumed then "assumption" else "assertion"
+        val okLabel = new Label()
+        generateCode(formulaExpr, ctx)
+        mv.visitJumpInsn(Opcodes.IFNE, okLabel)
+        val descrWithPos = descriptiveWord ++ " violated" ++ assertion.getPosition.map(" at " ++ _.toString).getOrElse("") ++
+          ": " ++ descr
+        generateExceptionCode(ctx, StringLit(descrWithPos))
+        mv.visitLabel(okLabel)
 
       case other => throw new IllegalStateException(s"unexpected in backend: ${other.getClass}")
     }
+  }
+
+  private def generateExceptionCode(
+                                     ctx: CodeGenerationContext,
+                                     msg: Expr
+                                   )(implicit mv: MethodVisitor, outputName: String): Unit = {
+    val runtimeException = "java/lang/RuntimeException"
+    mv.visitTypeInsn(NEW, runtimeException)
+    mv.visitInsn(DUP)
+    generateCode(msg, ctx)
+    mv.visitMethodInsn(Opcodes.INVOKESPECIAL, runtimeException,
+      "<init>", s"(L$stringTypeStr;)V", false)
+    mv.visitInsn(Opcodes.ATHROW)
   }
 
   private def generateSequence(

--- a/src/main/scala/compiler/backend/Backend.scala
+++ b/src/main/scala/compiler/backend/Backend.scala
@@ -308,7 +308,7 @@ final class Backend[V <: ClassVisitor](
             case Times => Opcodes.IMUL
             case Div => Opcodes.IDIV
             case Modulo => Opcodes.IREM
-            case _ => throw new IllegalStateException(s"unexpected $operator in backend")
+            case _ => throw new AssertionError(s"unexpected $operator in backend")
           }
           val opcode = opcodeFor(tpe, intOpcode, shouldNotHappen())
           mv.visitInsn(opcode)
@@ -418,7 +418,7 @@ final class Backend[V <: ClassVisitor](
         generateExceptionCode(ctx, StringLit(descrWithPos))
         mv.visitLabel(okLabel)
 
-      case other => throw new IllegalStateException(s"unexpected in backend: ${other.getClass}")
+      case other => throw new AssertionError(s"unexpected in backend: ${other.getClass}")
     }
   }
 

--- a/src/main/scala/compiler/desugarer/Replacer.scala
+++ b/src/main/scala/compiler/desugarer/Replacer.scala
@@ -4,6 +4,9 @@ import compiler.irs.Asts.*
 
 object Replacer {
 
+  /**
+   * Replace variables in `expr` according to the `renameMap`
+   */
   def replaceInExpr[E <: Expr](expr: E, renameMap: Map[String, Expr]): E = {
     replaceInExprImpl(expr)(renameMap)
   }
@@ -40,7 +43,7 @@ object Replacer {
         ForLoop(initStats.map(renameInStat), replaceInExprImpl(cond), stepStats.map(renameInStat), renameInStat(body), invariants.map(replaceInExprImpl))
       case ReturnStat(optVal) => ReturnStat(optVal.map(replaceInExprImpl))
       case Assertion(formulaExpr, descr, isAssumed) =>
-        Assertion(replaceInExprImpl(formulaExpr), descr, isAssumed).withPos(stat.getPosition)
+        Assertion(replaceInExprImpl(formulaExpr), descr, isAssumed).setPositionSp(stat.getPosition)
       case _: PanicStat => stat
       case _: LocalDef => assert(false)
     }

--- a/src/main/scala/compiler/desugarer/Replacer.scala
+++ b/src/main/scala/compiler/desugarer/Replacer.scala
@@ -1,4 +1,4 @@
-package compiler
+package compiler.desugarer
 
 import compiler.irs.Asts.*
 
@@ -39,7 +39,8 @@ object Replacer {
       case ForLoop(initStats, cond, stepStats, body, invariants) =>
         ForLoop(initStats.map(renameInStat), replaceInExprImpl(cond), stepStats.map(renameInStat), renameInStat(body), invariants.map(replaceInExprImpl))
       case ReturnStat(optVal) => ReturnStat(optVal.map(replaceInExprImpl))
-      case Assertion(formulaExpr, isAssumed) => Assertion(replaceInExprImpl(formulaExpr), isAssumed)
+      case Assertion(formulaExpr, descr, isAssumed) =>
+        Assertion(replaceInExprImpl(formulaExpr), descr, isAssumed).withPos(stat.getPosition)
       case _: PanicStat => stat
       case _: LocalDef => assert(false)
     }

--- a/src/main/scala/compiler/irs/Asts.scala
+++ b/src/main/scala/compiler/irs/Asts.scala
@@ -406,8 +406,13 @@ object Asts {
     override def getTypeOpt: Option[Type] = expr.getTypeOpt
   }
 
-  final case class Assertion(formulaExpr: Expr, isAssumed: Boolean = false) extends Statement {
+  final case class Assertion(formulaExpr: Expr, descr: String, isAssumed: Boolean = false) extends Statement {
     override def children: List[Ast] = List(formulaExpr)
+    
+    def withPos(posOpt: Option[Position]): Assertion = {
+      setPosition(posOpt)
+      this
+    }
 
     def keyword: Keyword = if isAssumed then Assume else Assert
   }

--- a/src/main/scala/compiler/irs/Asts.scala
+++ b/src/main/scala/compiler/irs/Asts.scala
@@ -408,8 +408,11 @@ object Asts {
 
   final case class Assertion(formulaExpr: Expr, descr: String, isAssumed: Boolean = false) extends Statement {
     override def children: List[Ast] = List(formulaExpr)
-    
-    def withPos(posOpt: Option[Position]): Assertion = {
+
+    /**
+     * Specialized version of `setPosition`: set the position and return this
+     */
+    def setPositionSp(posOpt: Option[Position]): Assertion = {
       setPosition(posOpt)
       this
     }

--- a/src/main/scala/compiler/parser/Parser.scala
+++ b/src/main/scala/compiler/parser/Parser.scala
@@ -84,10 +84,19 @@ final class Parser(errorReporter: ErrorReporter) extends CompilerStep[(List[Posi
 
   private lazy val topLevelDef: P[TopLevelDef] = funDef OR structDef
 
+  private lazy val precond = {
+    kw(Require).ignored ::: expr
+  } setName "precond"
+
+  private lazy val postcond = {
+    kw(Ensure).ignored ::: expr
+  } setName "postcond"
+
   private lazy val funDef = {
-    kw(Fn).ignored ::: lowName ::: openParenth ::: repeatWithSep(param, comma) ::: closeParenth ::: opt(-> ::: tpe) ::: block map {
-      case funName ^: params ^: optRetType ^: body =>
-        FunDef(funName, params, optRetType, body)
+    kw(Fn).ignored ::: lowName ::: openParenth ::: repeatWithSep(param, comma) ::: closeParenth ::: opt(-> ::: tpe)
+      ::: repeat(precond) ::: block ::: repeat(postcond) map {
+      case funName ^: params ^: optRetType ^: preconditions ^: body ^: postconditions =>
+        FunDef(funName, params, optRetType, body, preconditions, postconditions)
     }
   } setName "funDef"
 
@@ -207,7 +216,7 @@ final class Parser(errorReporter: ErrorReporter) extends CompilerStep[(List[Posi
   } setName "structInit"
 
   private lazy val stat: P[Statement] = {
-    exprOrAssig OR valDef OR varDef OR whileLoop OR forLoop OR ifThenElse OR returnStat OR panicStat
+    exprOrAssig OR valDef OR varDef OR whileLoop OR forLoop OR ifThenElse OR returnStat OR panicStat OR assertStat OR assumeStat
   } setName "stat"
 
   private lazy val valDef = {
@@ -222,15 +231,20 @@ final class Parser(errorReporter: ErrorReporter) extends CompilerStep[(List[Posi
     }
   } setName "varDef"
 
+  private lazy val invariant = {
+    kw(Invar).ignored ::: expr
+  } setName "invar"
+
   private lazy val whileLoop = recursive {
-    kw(While).ignored ::: expr ::: block map {
-      case cond ^: body => WhileLoop(cond, body)
+    kw(While).ignored ::: expr ::: repeat(invariant) ::: block map {
+      case cond ^: invars ^: body => WhileLoop(cond, body, invars)
     }
   } setName "whileLoop"
 
   private lazy val forLoop = recursive {
-    kw(For).ignored ::: repeatWithSep(valDef OR varDef OR assignmentStat, comma) ::: semicolon ::: expr ::: semicolon ::: repeatWithSep(assignmentStat, comma) ::: block map {
-      case initStats ^: cond ^: stepStats ^: body => ForLoop(initStats, cond, stepStats, body)
+    kw(For).ignored ::: repeatWithSep(valDef OR varDef OR assignmentStat, comma) ::: semicolon
+      ::: expr ::: semicolon ::: repeatWithSep(assignmentStat, comma) ::: repeat(invariant) ::: block map {
+      case initStats ^: cond ^: stepStats ^: invars ^: body => ForLoop(initStats, cond, stepStats, body, invars)
     }
   } setName "forLoop"
 
@@ -253,6 +267,14 @@ final class Parser(errorReporter: ErrorReporter) extends CompilerStep[(List[Posi
   private lazy val panicStat = {
     kw(Panic).ignored ::: expr map PanicStat.apply
   } setName "panicStat"
+
+  private lazy val assertStat = {
+    kw(Assert).ignored ::: expr map (formula => Assertion(formula))
+  } setName "assertStat"
+
+  private lazy val assumeStat = {
+    kw(Assume).ignored ::: expr map (formula => Assertion(formula, isAssumed = true))
+  } setName "assumeStat"
 
 
   override def apply(input: (List[PositionedToken], String)): Source = {

--- a/src/main/scala/compiler/parser/Parser.scala
+++ b/src/main/scala/compiler/parser/Parser.scala
@@ -5,6 +5,7 @@ import compiler.irs.Asts.*
 import compiler.irs.Tokens.*
 import compiler.parser.ParseTree.^:
 import compiler.parser.TreeParsers.{AnyTreeParser, FinalTreeParser, opt, recursive, repeat, repeatNonZero, repeatWithEnd, repeatWithSep, treeParser}
+import compiler.prettyprinter.PrettyPrinter
 import compiler.{CompilationStep, CompilerStep, Errors, Position}
 import lang.Keyword.*
 import lang.Operator.*
@@ -269,11 +270,11 @@ final class Parser(errorReporter: ErrorReporter) extends CompilerStep[(List[Posi
   } setName "panicStat"
 
   private lazy val assertStat = {
-    kw(Assert).ignored ::: expr map (formula => Assertion(formula))
+    kw(Assert).ignored ::: expr map (formula => Assertion(formula, PrettyPrinter.prettyPrintExpr(formula)))
   } setName "assertStat"
 
   private lazy val assumeStat = {
-    kw(Assume).ignored ::: expr map (formula => Assertion(formula, isAssumed = true))
+    kw(Assume).ignored ::: expr map (formula => Assertion(formula, PrettyPrinter.prettyPrintExpr(formula), isAssumed = true))
   } setName "assumeStat"
 
 

--- a/src/main/scala/compiler/prettyprinter/PrettyPrinter.scala
+++ b/src/main/scala/compiler/prettyprinter/PrettyPrinter.scala
@@ -222,8 +222,6 @@ final class PrettyPrinter(indentGranularity: Int = 2, displayAllParentheses: Boo
         addAssertions(Invar, invariants)
         if (invariants.nonEmpty){
           pps.newLine()
-        } else {
-          pps.addSpace()
         }
         addAst(body)
 
@@ -272,7 +270,7 @@ final class PrettyPrinter(indentGranularity: Int = 2, displayAllParentheses: Boo
           .addSpace()
         addAst(msg)
 
-      case assertion@Assertion(formulaExpr, _) =>
+      case assertion@Assertion(formulaExpr, _, _) =>
         pps
           .add(assertion.keyword.str)
           .addSpace()
@@ -356,6 +354,14 @@ final class PrettyPrinter(indentGranularity: Int = 2, displayAllParentheses: Boo
       }
     }
     pps.add(parenth._2)
+  }
+
+}
+
+object PrettyPrinter {
+
+  def prettyPrintExpr(expr: Expr, displayAllParentheses: Boolean = false): String = {
+    new PrettyPrinter(displayAllParentheses = displayAllParentheses).apply(expr)
   }
 
 }

--- a/src/main/scala/compiler/prettyprinter/PrettyPrinter.scala
+++ b/src/main/scala/compiler/prettyprinter/PrettyPrinter.scala
@@ -222,6 +222,8 @@ final class PrettyPrinter(indentGranularity: Int = 2, displayAllParentheses: Boo
         addAssertions(Invar, invariants)
         if (invariants.nonEmpty){
           pps.newLine()
+        } else {
+          pps.addSpace()
         }
         addAst(body)
 

--- a/src/main/scala/compiler/typechecker/TypeChecker.scala
+++ b/src/main/scala/compiler/typechecker/TypeChecker.scala
@@ -500,8 +500,11 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
   private def checkVerificationFormulas(formulas: List[(Expr, Option[Position])], ctx: TypeCheckingContext): Unit = {
     for (formulaExpr, pos) <- formulas do {
       val formulaType = check(formulaExpr, ctx)
-      if (formulaType != BoolType) {
+      if (!formulaType.subtypeOf(BoolType)) {
         reportError(s"formulas in assert and assume statements must have result type '${BoolType.str}', found '$formulaType'", pos)
+      }
+      if (!formulaExpr.isPurelyFunctional){
+        reportError("verification formulas should not contain side effects or function calls", pos)
       }
     }
   }

--- a/src/main/scala/compiler/typechecker/TypeChecker.scala
+++ b/src/main/scala/compiler/typechecker/TypeChecker.scala
@@ -5,6 +5,7 @@ import compiler.Errors.{CompilationError, Err, ErrorReporter, Warning}
 import compiler.irs.Asts.*
 import compiler.{AnalysisContext, CompilerStep, Position}
 import lang.Operator.{Equality, Inequality, Sharp}
+import lang.SoftKeywords.Result
 import lang.{Operators, TypeConversion}
 import lang.Types.*
 import lang.Types.PrimitiveType.*
@@ -44,36 +45,19 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
         }
         VoidType
 
-      case funDef@FunDef(funName, params, optRetType, body) =>
+      case funDef@FunDef(funName, params, optRetType, body, precond, postcond) =>
         optRetType.foreach { retType =>
-          if (!ctx.analysisContext.knowsType(retType)){
+          if (!ctx.analysisContext.knowsType(retType)) {
             reportError(s"return type is unknown: '$retType'", funDef.getPosition)
           }
         }
+        checkFunctionBody(ctx, funName, params, body)
         val expRetType = optRetType.getOrElse(VoidType)
-        val ctxWithParams = ctx.copyWithoutLocals
-        for param <- params do {
-          val typeIsKnown = ctx.analysisContext.knowsType(param.tpe)
-          if (!typeIsKnown) {
-            reportError(s"unknown type: ${param.tpe}", param.getPosition)
-          }
-          val paramType = if typeIsKnown then param.tpe else UndefinedType
-          ctxWithParams.addLocal(param.paramName, paramType, false, duplicateVarCallback = { () =>
-            reportError(s"identifier '${param.paramName}' is already used by another parameter of function '$funName'", param.getPosition)
-          }, forbiddenTypeCallback = { () =>
-            reportError(s"parameter '${param.paramName}' of function '$funName' has type '$paramType', which is forbidden", param.getPosition)
-          })
+        checkFuncReturnStats(funDef, funName, body, expRetType)
+        if (funDef.params.exists(_.paramName == Result.str)) {
+          errorReporter.push(Err(TypeChecking, s"function arguments cannot be named '$Result'", funDef.getPosition))
         }
-        check(body, ctxWithParams)
-        val endStatus = checkReturns(body)
-        if (!endStatus.alwaysStopped && !expRetType.subtypeOf(VoidType)) {
-          reportError("missing return in non-Void function", funDef.getPosition)
-        }
-        val faultyTypes = endStatus.returned.filter(!_.subtypeOf(expRetType))
-        if (faultyTypes.nonEmpty) {
-          val faultyTypeStr = faultyTypes.map("'" + _ + "'").mkString(", ")
-          reportError(s"function '$funName' should return '$expRetType', found $faultyTypeStr", funDef.getPosition)
-        }
+        checkPreAndPostcond(ctx, funDef, params, precond, postcond, expRetType)
         VoidType
 
       case localDef@LocalDef(localName, optType, rhs, isReassignable) =>
@@ -111,7 +95,7 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
       case call@Call(callee, args) =>
         callee match {
           case varRef@VariableRef(name) =>
-            ctx.functions.get(name) match {
+            ctx.functions.get(name).map(_.sig) match {
               case Some(funSig) =>
                 varRef.setType(UndefinedType) // useless but o.w. the check that all expressions have a type fails
                 checkCallArgs(funSig.argTypes, args, ctx, call.getPosition)
@@ -303,15 +287,16 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
           reportError(s"type mismatch in ternary operator: first branch has type $thenType, second has type $elseType", ternary.getPosition)
         }
 
-      case whileLoop@WhileLoop(cond, body) =>
+      case whileLoop@WhileLoop(cond, body, invariants) =>
         val condType = check(cond, ctx)
         if (!condType.subtypeOf(BoolType)) {
           reportError(s"condition should be of type '${BoolType.str}', found '$condType'", whileLoop.getPosition)
         }
         check(body, ctx)
+        checkVerificationFormulas(invariants.map((_, whileLoop.getPosition)), ctx)
         VoidType
 
-      case forLoop@ForLoop(initStats, cond, stepStats, body) =>
+      case forLoop@ForLoop(initStats, cond, stepStats, body, invariants) =>
         val newCtx = ctx.copied
         initStats.foreach(check(_, newCtx))
         val condType = check(cond, newCtx)
@@ -320,6 +305,7 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
         }
         stepStats.foreach(check(_, newCtx))
         check(body, newCtx)
+        checkVerificationFormulas(invariants.map((_, forLoop.getPosition)), ctx)
         VoidType
 
       case ReturnStat(valueOpt) =>
@@ -344,6 +330,10 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
         }
         NothingType
 
+      case assertion@Assertion(formulaExpr, _) =>
+        checkVerificationFormulas(List((formulaExpr, assertion.getPosition)), ctx)
+        VoidType
+
       case _: (Param | Sequence) => assert(false)
     }
     // if expression save type
@@ -352,6 +342,54 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
       case _ => ()
     }
     tpe
+  }
+
+  private def checkFuncReturnStats(funDef: FunDef, funName: String, body: Block, expRetType: Type) = {
+    val endStatus = checkReturns(body)
+    if (!endStatus.alwaysStopped && !expRetType.subtypeOf(VoidType)) {
+      reportError("missing return in non-Void function", funDef.getPosition)
+    }
+    val faultyTypes = endStatus.returned.filter(!_.subtypeOf(expRetType))
+    if (faultyTypes.nonEmpty) {
+      val faultyTypeStr = faultyTypes.map("'" + _ + "'").mkString(", ")
+      reportError(s"function '$funName' should return '$expRetType', found $faultyTypeStr", funDef.getPosition)
+    }
+  }
+
+  private def checkFunctionBody(ctx: TypeCheckingContext, funName: String, params: List[Param], body: Block) = {
+    val ctxWithParams = ctx.copyWithoutLocals
+    for param <- params do {
+      val typeIsKnown = ctx.analysisContext.knowsType(param.tpe)
+      if (!typeIsKnown) {
+        reportError(s"unknown type: ${param.tpe}", param.getPosition)
+      }
+      val paramType = if typeIsKnown then param.tpe else UndefinedType
+      ctxWithParams.addLocal(param.paramName, paramType, false, duplicateVarCallback = { () =>
+        reportError(s"identifier '${param.paramName}' is already used by another parameter of function '$funName'", param.getPosition)
+      }, forbiddenTypeCallback = { () =>
+        reportError(s"parameter '${param.paramName}' of function '$funName' has type '$paramType', which is forbidden", param.getPosition)
+      })
+    }
+    check(body, ctxWithParams)
+  }
+
+  private def checkPreAndPostcond(ctx: TypeCheckingContext, funDef: FunDef, params: List[Param], precond: List[Expr], postcond: List[Expr], retType: Type): Unit = {
+    val precondCtx = ctx.copyWithoutLocals
+    for param <- params do {
+      precondCtx.addLocal(param.paramName, param.tpe, isReassignable = false, () => assert(false), () => assert(false))
+    }
+    checkVerificationFormulas(precond.map((_, funDef.getPosition)), precondCtx)
+    val retTypeAdmitsPostcond = retType != VoidType && retType != NothingType
+    if (retTypeAdmitsPostcond){
+      val postcondCtx = ctx.copyWithoutLocals
+      for param <- params do {
+        postcondCtx.addLocal(param.paramName, param.tpe, isReassignable = false, () => assert(false), () => assert(false))
+      }
+      postcondCtx.addLocal(Result.str, retType, isReassignable = false, () => assert(false), () => assert(false))
+      checkVerificationFormulas(postcond.map((_, funDef.getPosition)), postcondCtx)
+    } else if (postcond.nonEmpty) {
+      reportError(s"postcondition on function with '${retType}' return type", funDef.getPosition)
+    }
   }
 
   private def checkCallArgs(expTypes: List[Type], args: List[Expr], ctx: TypeCheckingContext, callPos: Option[Position]): Unit = {
@@ -427,14 +465,14 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
 
       case _: Ternary => EndStatus(Set.empty, false)
 
-      case whileLoop@WhileLoop(_, body) =>
+      case whileLoop@WhileLoop(_, body, _) =>
         val bodyEndStatus = checkReturns(body)
         if (bodyEndStatus.alwaysStopped) {
           reportError("while should be replaced by if", whileLoop.getPosition, isWarning = true)
         }
         EndStatus(bodyEndStatus.returned, false)
 
-      case forLoop@ForLoop(_, _, _, body) =>
+      case forLoop@ForLoop(_, _, _, body, _) =>
         val bodyEndStatus = checkReturns(body)
         if (bodyEndStatus.alwaysStopped) {
           reportError("for should be replaced by if", forLoop.getPosition, isWarning = true)
@@ -456,6 +494,15 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
 
       case _ => EndStatus(Set.empty, false)
 
+    }
+  }
+
+  private def checkVerificationFormulas(formulas: List[(Expr, Option[Position])], ctx: TypeCheckingContext): Unit = {
+    for (formulaExpr, pos) <- formulas do {
+      val formulaType = check(formulaExpr, ctx)
+      if (formulaType != BoolType) {
+        reportError(s"formulas in assert and assume statements must have result type '${BoolType.str}', found '$formulaType'", pos)
+      }
     }
   }
 

--- a/src/main/scala/compiler/typechecker/TypeChecker.scala
+++ b/src/main/scala/compiler/typechecker/TypeChecker.scala
@@ -317,7 +317,7 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
         if (exprTpe.subtypeOf(tpe)) {
           reportError(s"useless conversion: '$exprTpe' --> '$tpe'", cast.getPosition, isWarning = true)
           tpe
-        } else if (TypeConversion.conversionFor(exprTpe, tpe).isDefined){
+        } else if (TypeConversion.conversionFor(exprTpe, tpe).isDefined) {
           tpe
         } else {
           reportError(s"cannot cast ${expr.getType} to $tpe", cast.getPosition)
@@ -373,14 +373,21 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
     check(body, ctxWithParams)
   }
 
-  private def checkPreAndPostcond(ctx: TypeCheckingContext, funDef: FunDef, params: List[Param], precond: List[Expr], postcond: List[Expr], retType: Type): Unit = {
+  private def checkPreAndPostcond(
+                                   ctx: TypeCheckingContext,
+                                   funDef: FunDef,
+                                   params: List[Param],
+                                   precond: List[Expr],
+                                   postcond: List[Expr],
+                                   retType: Type
+                                 ): Unit = {
     val precondCtx = ctx.copyWithoutLocals
     for param <- params do {
       precondCtx.addLocal(param.paramName, param.tpe, isReassignable = false, () => assert(false), () => assert(false))
     }
     checkVerificationFormulas(precond.map((_, funDef.getPosition)), precondCtx)
     val retTypeAdmitsPostcond = retType != VoidType && retType != NothingType
-    if (retTypeAdmitsPostcond){
+    if (retTypeAdmitsPostcond) {
       val postcondCtx = ctx.copyWithoutLocals
       for param <- params do {
         postcondCtx.addLocal(param.paramName, param.tpe, isReassignable = false, () => assert(false), () => assert(false))
@@ -418,7 +425,7 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
   }
 
   /**
-   * @param returned types of all the expressions found after a `return`
+   * @param returned      types of all the expressions found after a `return`
    * @param alwaysStopped indicates whether the control-flow can reach the end of the considered construct without
    *                      encountering an instruction that terminates the function (`return` or `panic`)
    */
@@ -503,7 +510,7 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
       if (!formulaType.subtypeOf(BoolType)) {
         reportError(s"formulas in assert and assume statements must have result type '${BoolType.str}', found '$formulaType'", pos)
       }
-      if (!formulaExpr.isPurelyFunctional){
+      if (!formulaExpr.isPurelyFunctional) {
         reportError("verification formulas should not contain side effects or function calls", pos)
       }
     }

--- a/src/main/scala/compiler/typechecker/TypeChecker.scala
+++ b/src/main/scala/compiler/typechecker/TypeChecker.scala
@@ -330,7 +330,7 @@ final class TypeChecker(errorReporter: ErrorReporter) extends CompilerStep[(List
         }
         NothingType
 
-      case assertion@Assertion(formulaExpr, _) =>
+      case assertion@Assertion(formulaExpr, _, _) =>
         checkVerificationFormulas(List((formulaExpr, assertion.getPosition)), ctx)
         VoidType
 

--- a/src/main/scala/lang/Keyword.scala
+++ b/src/main/scala/lang/Keyword.scala
@@ -16,6 +16,11 @@ enum Keyword(val str: String) {
   case New extends Keyword("new")
   case As extends Keyword("as")
   case Panic extends Keyword("panic")
+  case Assert extends Keyword("assert")
+  case Assume extends Keyword("assume")
+  case Require extends Keyword("require")
+  case Ensure extends Keyword("ensure")
+  case Invar extends Keyword("invar")
 
   override def toString: String = str
 }

--- a/src/main/scala/lang/SoftKeywords.scala
+++ b/src/main/scala/lang/SoftKeywords.scala
@@ -1,0 +1,5 @@
+package lang
+
+enum SoftKeywords(val str: String) {
+  case Result extends SoftKeywords("result")
+}

--- a/src/test/res/assertions.rsn
+++ b/src/test/res/assertions.rsn
@@ -1,0 +1,16 @@
+
+fn testFunc(x: String, y: String, counter: arr Int) -> String {
+    assert #x == #y;
+    var s = "";
+    var c = 'A' as Int;
+    var i = 0;
+    var j = 10;
+    while #s < #x invar j > i {
+        s += charToString(c as Char);
+        c += 1;
+        i += 1;
+        j -= 2;
+        counter[0] += 1;
+    };
+    return s
+}

--- a/src/test/res/forinvar.rsn
+++ b/src/test/res/forinvar.rsn
@@ -1,0 +1,10 @@
+
+fn bar(ys: String, x: Int, counter: arr Int) -> Char {
+    var s = 0;
+    val chars = toCharArray(ys);
+    var i = 0;
+    for ; i < x; i += 1, counter[0] += 1 invar i < #ys invar s >= 0 {
+        s += chars[i] as Int;
+    };
+    return chars[s % i]
+}

--- a/src/test/res/prepostcond.rsn
+++ b/src/test/res/prepostcond.rsn
@@ -1,0 +1,23 @@
+
+
+fn isMaxInArray(xs: arr Int, idx: Int) -> String
+require idx >= 0
+require idx < #xs
+{
+    for var i = 0; i < #xs; i += 1 {
+        if i == idx {
+            i += 1;
+            return "Hey I'm a bug!"
+        };
+        if xs[i] > xs[idx] {
+            return "no"
+        }
+    };
+    return "yes"
+}
+ensure result == "yes" || result == "no"
+
+
+fn testF(array: arr Int, idx: Int) -> String {
+    return isMaxInArray(array, idx)
+}

--- a/src/test/res/verifconstr.rsn
+++ b/src/test/res/verifconstr.rsn
@@ -14,6 +14,6 @@ require x > 0
 ensure result > 24
 
 
-fn main() -> Void {
-    print(intToString(foo(10, 20)))
+fn testF() -> Int {
+    return foo(30, 20)
 }

--- a/src/test/res/verifconstr.rsn
+++ b/src/test/res/verifconstr.rsn
@@ -12,3 +12,8 @@ require x > 0
     return a
 }
 ensure result > 24
+
+
+fn main() -> Void {
+    print(intToString(foo(10, 20)))
+}

--- a/src/test/res/verifconstr.rsn
+++ b/src/test/res/verifconstr.rsn
@@ -1,0 +1,14 @@
+
+fn foo(x: Int, y: Int) -> Int
+require x > y
+require x > 0
+{
+    var a = -10;
+    val b = 1 + 1;
+    assert b > a;
+    while a < 25 invar a % 2 == 0 {
+        a += b*(x-y)
+    };
+    return a
+}
+ensure result > 24

--- a/src/test/scala/compiler/CompilerTests.scala
+++ b/src/test/scala/compiler/CompilerTests.scala
@@ -241,6 +241,12 @@ class CompilerTests {
     assertEquals(expectedRes, actualRes)
   }
 
+  @Test
+  def verificationConstructsTest(): Unit = {
+    val res = compileAndExecOneIter("verifconstr", "foo", 15, 88)
+    assertEquals(2, res)
+  }
+
   private def compileAndExecOneIter(srcFileName: String, testedMethodName: String, args: Any*): Any = {
     compileAndExecSeveralIter(srcFileName, testedMethodName, List(args.toArray)).head
   }

--- a/src/test/scala/compiler/CompilerTests.scala
+++ b/src/test/scala/compiler/CompilerTests.scala
@@ -297,13 +297,25 @@ class CompilerTests {
     assertEquals(4, counter(0))
   }
 
+  @Test
+  def forLoopInvarTest(): Unit = {
+    val counter = Array(0)
+    val inputStr = "EPFL > ETH :-)"
+    assertThrowsInvocationTarget {
+      () => compileAndExecOneIter("forinvar", "bar", inputStr, 21, counter)
+    }{ e =>
+      assertTrue(e.getMessage.contains("i < #y"))
+    }
+    assertEquals(inputStr.length, counter(0))
+  }
+
   /**
    * <b>Use with care!</b> Always test that a failure actually fails the test
    */
   private def assertThrowsInvocationTarget(callable: () => Unit)(checksOnException: RuntimeException => Unit): Unit = {
     try {
       callable()
-      fail("no exception was thrown")
+      fail(s"no exception was thrown, but expected ${classOf[RuntimeException]}")
     } catch {
       case e: InvocationTargetException if e.getCause.isInstanceOf[RuntimeException] =>
         checksOnException(e.getCause.asInstanceOf[RuntimeException])


### PR DESCRIPTION
### ASTs for assertions, pre/postconditions and invariants
- New AST for assert and assume (the same, with a boolean `isAssumed` to distinguish between assertions and assumptions)
- Pre/postconditions are stored in the corresponding FunDef node
- Invariants are stored in the corresponding loop

### Parsing of the new ASTs

### Typechecking of the new ASTs
- Introduction of a soft keyword `result` as discussed
- Forbid function calls in assertions (the idea being to use predicates instead)

### Prettyprinting of the new ASTs

### Code generation for the new ASTs
Evaluate the asserted condition, if false throw an exception

### Desugaring of the new ASTs
- Preconditions become assertions at call site and assumptions inside the function
- Postconditions become assumptions at call site and assertions on the return values
- Loop invariants are desugared into an assertion at the beginning of the loop body and another assertion right after the loop

Run `desugar -out-dir=testout src/test/res/verifconstr.rsn` to see an example of how these constructs are desugared.

### Desugaring of operators
The desugarer now takes an argument telling whether operators should be desugared (e.g. `x && y` --> `when x then y else false`) or not. It should be done before sending the AST to the backend, but not when sending it to the verification system.